### PR TITLE
Add file sync GitHub workflow

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,8 @@
+group:
+  - files:
+    - source: .gitsecret/
+      dest: .gitsecret/
+    - source: secrets/
+      dest: .balena/secrets/
+    repos: |
+      product-os/jellyfish-plugin-typeform

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,24 @@
+# This workflow synchronizes files from this repo into other repos
+# if they have changed. The 'magic' happens thanks to this action:
+# https://github.com/marketplace/actions/repo-file-sync-action
+
+name: Sync Files
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@master
+      - name: Run GitHub File Sync
+        uses: BetaHuhn/repo-file-sync-action@v1.8.0
+        with:
+          GH_PAT: ${{ secrets.GH_PAT }}
+          COMMIT_BODY: "Change-type: patch"
+          COMMIT_EACH_FILE: false


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Add GitHub workflow configs to sync git secrets to consumer repos.