### PR TITLE
Add other sync targets

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -13,3 +13,7 @@ group:
       product-os/jellyfish-plugin-front
       product-os/jellyfish-plugin-discourse
       product-os/jellyfish-queue
+      product-os/jellyfish-worker
+      product-os/jellyfish-core
+      product-os/jellyfish-action-library
+      product-os/jellyfish-plugin-default


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Add the following repos as sync targets:
- `jellyfish-queue`
- `jellyfish-worker`
- `jellyfish-core`
- `jellyfish-action-library`
- `jellyfish-plugin-default`