### PR TITLE
Set sync action version to v1

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@master
       - name: Run GitHub File Sync
-        uses: BetaHuhn/repo-file-sync-action@v1.13.3
+        uses: BetaHuhn/repo-file-sync-action@v1
         with:
           GH_PAT: ${{ secrets.GH_PAT }}
           COMMIT_BODY: "Change-type: patch"


### PR DESCRIPTION
Set version to v1 to always use the latest version of v1.
This is the recommended usage and means we don't need to
worry about minor and patch bumps.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Using `v1` as the version is the [recommended usage](https://github.com/marketplace/actions/repo-file-sync-action#versioning).