### PR TITLE
Remove plugin-default from sync targets

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -16,5 +16,4 @@ group:
       product-os/jellyfish-worker
       product-os/jellyfish-core
       product-os/jellyfish-action-library
-      product-os/jellyfish-plugin-default
       product-os/jellyfish


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>