### PR TITLE
Remove jellyfish-worker from sync targets

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -12,7 +12,6 @@ group:
       product-os/jellyfish-plugin-github
       product-os/jellyfish-plugin-front
       product-os/jellyfish-plugin-discourse
-      product-os/jellyfish-worker
       product-os/jellyfish-core
       product-os/jellyfish-action-library
       product-os/jellyfish


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>