### PR TITLE
Add plugin-default as sync target

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -12,5 +12,5 @@ group:
       product-os/jellyfish-plugin-github
       product-os/jellyfish-plugin-front
       product-os/jellyfish-plugin-discourse
-      product-os/jellyfish-action-library
       product-os/jellyfish
+      product-os/jellyfish-plugin-default


### PR DESCRIPTION
Also drop action-library as we are
merging it into plugin-default

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>