### PR TITLE
Prune sync targets

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -5,12 +5,8 @@ group:
     - source: .balena/secrets/
       dest: .balena/secrets/
     repos: |
-      product-os/jellyfish-plugin-typeform
       product-os/jellyfish-plugin-balena-api
-      product-os/jellyfish-plugin-outreach
-      product-os/jellyfish-plugin-flowdock
       product-os/jellyfish-plugin-github
       product-os/jellyfish-plugin-front
       product-os/jellyfish-plugin-discourse
       product-os/jellyfish
-      product-os/jellyfish-plugin-default


### PR DESCRIPTION
Remove a few sync targets as
they no longer need secrets.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>